### PR TITLE
Use the production tegola image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,7 +91,7 @@ services:
 
 ### Tegola ##################################
   tegola:
-    build: https://github.com/go-spatial/tegola.git#v0.14.0
+    image: gospatial/tegola:v0.14.0
     volumes:
       - ./maps-config/tegola/tegola.toml:/etc/tegola.toml
       - ${DATA_PATH_HOST}/tegola/cache:/etc/cache


### PR DESCRIPTION
The development image is designed to be rebuilt any time the source
changes, and something in the build steps change the directory
contents thereby causing a full rebuild every run.  Using the
production image will be more efficient as long as we aren't changing
tegola source, because it will never need a rebuild.