### PR TITLE
Set reasonable allowDomains; alias wiki to gateway

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,6 @@ services:
       - ./maps-config/osm-bright.tm2source/imposm_mapping.yml:/etc/imposm/mapping.yml
       - ./workspace/osm-initial-import.sh:/usr/bin/osm-initial-import
 
-    extra_hosts:
-      - "dockerhost:${DOCKER_HOST_IP}"
     tty: true
     networks:
       - frontend
@@ -58,6 +56,8 @@ services:
     networks:
       - frontend
       - backend
+    extra_hosts:
+      - dev.wiki.local.wmftest.net:host-gateway
 
 ### PostgreSQL PostGis ##################################
   postgres-postgis:

--- a/env-example
+++ b/env-example
@@ -22,11 +22,6 @@ VOLUMES_DRIVER=local
 # All Networks driver
 NETWORKS_DRIVER=bridge
 
-### Docker Host IP ########################################
-
-# Enter your Docker Host IP (will be appended to /etc/hosts). Default is `10.0.75.1`
-DOCKER_HOST_IP=172.17.0.1
-
 ### WORKSPACE ########################################
 
 WORKSPACE_SSH_PORT=2221

--- a/kartotherian/config.kartotherian.docker.template.yaml
+++ b/kartotherian/config.kartotherian.docker.template.yaml
@@ -94,11 +94,12 @@ services:
         user: $PGUSER
         wikidataQueryService: https://query.wikidata.org/bigdata/namespace/wdq/sparql
 
-      # allowedDomains:
-      #   http:
-      #     - localhost:8080
-      #     - 127.0.0.1:8080
-      #     - wmflabs.org
+      allowedDomains:
+         http:
+           - localhost
+           - 127.0.0.1
+           - wmflabs.org
+           - wmftest.net
       #   https:
       #     - mediawiki.org
       #     - wikibooks.org


### PR DESCRIPTION
This is required configuration, so we should enable a few typical development and staging domains by default.

Hosts have no port numbers, in anticipation of the other work to simplify domains.

[Bug: T301769](https://phabricator.wikimedia.org/T301769)