### PR TITLE
Internal port never changes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,7 @@ services:
       - "${TEGOLA_PORT:-8080}:8080"
     environment:
       - DB_HOST=postgres-postgis
-      - DB_PORT=${PGPORT}
+      - DB_PORT=5432
       - DB_USER=${PGUSER}
       - DB_PASSWORD=${PGPASSWORD}
       - DB_NAME=${PGDATABASE}


### PR DESCRIPTION
The postgres port number can be configured to avoid collision with
a host service, but this only affects the port exposed on the host.
The container will always serve on port 5432, so internal connections
to the db should use the constant and not the parameterized external
number.