### PR TITLE
Add flag to build libxmljs from source

### DIFF
--- a/makefile
+++ b/makefile
@@ -15,7 +15,7 @@ npm_test:
 	docker-compose exec kartotherian bash -c ". /.nvm/nvm.sh && nvm use 10.15.2 && npm test"
 
 npm_install:
-	docker-compose exec kartotherian bash -c ". /.nvm/nvm.sh && nvm use 10.15.2 && npm install --unsafe-perm"
+	docker-compose exec kartotherian bash -c ". /.nvm/nvm.sh && nvm use 10.15.2 && npm install --unsafe-perm --build-from-source libxmljs"
 
 npm_link:
 	docker-compose exec kartotherian bash -c "cd /srv/dependencies/osm-bright.tm2source && . /.nvm/nvm.sh && nvm use 10.15.2 && npm link"


### PR DESCRIPTION
Avoids conflicts with differing GLIBC versions on the host system, and allows using newer versions of the npm library.

The current libxmljs version has a bunch of vulnerabilities and a minor version upgrade would fix some of these. The only blocker is GLIBC compatibility. But that can be fixed by compiling on install.