### PR TITLE
Update postgis in test instance

### DIFF
--- a/smoketests/test.Dockerfile
+++ b/smoketests/test.Dockerfile
@@ -1,4 +1,4 @@
-FROM postgis/postgis:11-2.5
+FROM postgis/postgis:11-3.1
 
 RUN apt-get update \
  # install newer packages from backports


### PR DESCRIPTION
2.5 is not installable anymore. 3.1 is known to be supported in CI and production.