### PR TITLE
Replace docker-compose with `docker compose`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,5 +13,5 @@ jobs:
       - uses: actions/checkout@v2
       - name: Update git submodule
         run: git submodule update --init --recursive --merge
-      - name: Run test job with docker-compose
-        run: docker-compose run --rm test
+      - name: Run test job with docker compose
+        run: docker compose run --rm test

--- a/makefile
+++ b/makefile
@@ -6,40 +6,40 @@ include .env
 # Usage: make osm \
 # 			ARGS='-p http://download.geofabrik.de/asia/israel-and-palestine-latest.osm.pbf'
 osm:
-	docker-compose exec workspace osm-initial-import $(ARGS) -s -H postgres-postgis
+	docker compose exec workspace osm-initial-import $(ARGS) -s -H postgres-postgis
 
 run_kartotherian:
-	docker-compose exec kartotherian nodemon --ext js,json,yaml --signal SIGHUP server.js -c config.docker.yaml
+	docker compose exec kartotherian nodemon --ext js,json,yaml --signal SIGHUP server.js -c config.docker.yaml
 
 npm_test:
-	docker-compose exec kartotherian npm test
+	docker compose exec kartotherian npm test
 
 npm_install:
-	docker-compose exec kartotherian npm install --unsafe-perm
+	docker compose exec kartotherian npm install --unsafe-perm
 
 npm_link:
-	docker-compose exec kartotherian -w /srv/dependencies/osm-bright.tm2source npm link
-	docker-compose exec kartotherian -w /srv/dependencies/osm-bright.tm2 npm link
-	docker-compose exec kartotherian -w /home/kartotherian/packages/kartotherian npm link @kartotherian/osm-bright-source
-	docker-compose exec kartotherian -w /home/kartotherian/packages/kartotherian npm link @kartotherian/osm-bright-style
+	docker compose exec kartotherian -w /srv/dependencies/osm-bright.tm2source npm link
+	docker compose exec kartotherian -w /srv/dependencies/osm-bright.tm2 npm link
+	docker compose exec kartotherian -w /home/kartotherian/packages/kartotherian npm link @kartotherian/osm-bright-source
+	docker compose exec kartotherian -w /home/kartotherian/packages/kartotherian npm link @kartotherian/osm-bright-style
 
 imposm_run:
-	docker-compose exec workspace imposm run -config /etc/imposm/config.json -expiretiles-zoom 15
+	docker compose exec workspace imposm run -config /etc/imposm/config.json -expiretiles-zoom 15
 
 # pregen_dequeue:
-#     docker-compose exec tegola /etc/pregenerate-maps-tile.sh
+#     docker compose exec tegola /etc/pregenerate-maps-tile.sh
 #
 # pregen_enqueue:
-#     docker-compose exec tegola poppy --broker-url redis://redis:6379 --queue-name pregen enqueue --message-entry tile 1/1/1
+#     docker compose exec tegola poppy --broker-url redis://redis:6379 --queue-name pregen enqueue --message-entry tile 1/1/1
 
 install:
 	# TODO
 	# Check if kartotherian is installed and clone if it isn't
-	# docker-compose up --build kartotherian
+	# docker compose up --build kartotherian
 	# Execute (clean and?) npm install
 	# Execute osm-initial-import
 	# Execute keyspace_setup
 	# Execute kartotherian monorepo tests
 
 up:
-	docker-compose up --detach kartotherian
+	docker compose up --detach kartotherian


### PR DESCRIPTION
The alias with the dash apparently doesn't exist any more, or is just not needed any more separately.